### PR TITLE
Add support for React v15.x in `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash.assign": "^3.2.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0",
   },
   "tags": [
     "react",


### PR DESCRIPTION
When installing this package in a project that uses React v15.x the following warning is shown:

`npm WARN react-modal@0.6.1 requires a peer of react@^0.14.0 but none was installed.`

This commit solves that.